### PR TITLE
Point to types file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"install": "node build"
 	},
 	"main": "icon.js",
+	"types": "icon.d.ts",
 	"dependencies": {
 		"@iconify/json": "^1.0.65",
 		"@iconify/json-tools": "^1.0.5",


### PR DESCRIPTION
Overview
-----
This PR adds a `"types": "icon.d.ts"` entry to `package.json` so that the included types are able to be used.